### PR TITLE
Small bugfixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 node_modules
 nbproject
 .DS_Store
-package-lock.json
+npm-debug.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 nbproject
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 nbproject
 .DS_Store
+package-lock.json

--- a/lib/index.js
+++ b/lib/index.js
@@ -35,7 +35,7 @@ function singleFixture (name, obj, hook, opts, sails) {
       sails.log.error('Got error with ' + name + ' fixture: ' + err);
     })
     .finally(function () {
-      sails.emit(hook);
+      return sails.emit(hook);
     });
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sails-hook-fixtures",
-  "version": "1.0.0-beta",
+  "version": "1.0.1-beta",
   "description": "Automatically install database fixtures with relations to your database when you lift Sails",
   "main": "lib/index.js",
   "directories": {


### PR DESCRIPTION
The `finally()` call of the hook, caused a Warning, since it wasn't returning anything during emit, which is now fixed, also added some common gitignore exceptions.