### PR TITLE
Silence unhandled promise error

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -36,7 +36,8 @@ function singleFixture (name, obj, hook, opts, sails) {
       return;
     })
     .finally(function () {
-      return sails.emit(hook);
+      sails.emit(hook);
+      return null;
     });
   }
 }


### PR DESCRIPTION
Removes blocks reporting unhandled promises by explicitly returning null. 